### PR TITLE
Fix crash when expanded_url is nil

### DIFF
--- a/filter.rb
+++ b/filter.rb
@@ -52,7 +52,7 @@ Plugin.create(:filter) do
         false
       else
         m[:entities][:urls].map{|u| u[:expanded_url]}.any? do |url|
-          mute_words.any?{|w| url.include?(w)}
+          mute_words.any?{|w| url && url.include?(w)}
         end
       end
     end


### PR DESCRIPTION
## Problem

Mikutter crashes when expanded_url is nil.

```
/home/pocke/.mikutter/plugin/filter/filter.rb:59:in `block (5 levels) in <top (required)>': undefined method `include?' for nil:NilClass
         from /home/pocke/.mikutter/plugin/filter/filter.rb:59:in `any?'
         from /home/pocke/.mikutter/plugin/filter/filter.rb:59:in `block (4 levels) in <top (required)>'
         from /home/pocke/.mikutter/plugin/filter/filter.rb:54:in `any?'
         from /home/pocke/.mikutter/plugin/filter/filter.rb:54:in `block (3 levels) in <top (required)>'
         from /home/pocke/.mikutter/plugin/filter/filter.rb:50:in `reject'
         from /home/pocke/.mikutter/plugin/filter/filter.rb:50:in `block (2 levels) in <top (required)>'
         from /opt/mikutter/vendor/pluggaloid/filter.rb:28:in `filtering'
         from /opt/mikutter/vendor/pluggaloid/event.rb:59:in `block (2 levels) in filtering'
         from /opt/mikutter/vendor/pluggaloid/event.rb:58:in `each'
         from /opt/mikutter/vendor/pluggaloid/event.rb:58:in `reduce'
         from /opt/mikutter/vendor/pluggaloid/event.rb:58:in `block in filtering'
         from /opt/mikutter/vendor/pluggaloid/event.rb:57:in `catch'
         from /opt/mikutter/vendor/pluggaloid/event.rb:57:in `filtering'
         from /opt/mikutter/vendor/pluggaloid/plugin.rb:63:in `filtering'
         from /opt/mikutter/core/plugin/notify/notify.rb:24:in `block (2 levels) in <top (required)>'
         from /opt/mikutter/vendor/pluggaloid/listener.rb:25:in `call'
         from /opt/mikutter/vendor/pluggaloid/event.rb:97:in `block (2 levels) in call_all_listeners'
         from /opt/mikutter/vendor/pluggaloid/event.rb:96:in `each'
         from /opt/mikutter/vendor/pluggaloid/event.rb:96:in `block in call_all_listeners'
         from /opt/mikutter/vendor/pluggaloid/event.rb:95:in `catch'
         from /opt/mikutter/vendor/pluggaloid/event.rb:95:in `call_all_listeners'
         from /opt/mikutter/vendor/pluggaloid/event.rb:45:in `block (2 levels) in call'
         from /opt/mikutter/vendor/delayer/procedure.rb:24:in `run'
         from /opt/mikutter/vendor/delayer/extend.rb:58:in `run_once'
         from /opt/mikutter/vendor/delayer/extend.rb:30:in `run'
         from /opt/mikutter/vendor/delayer.rb:43:in `method_missing'
         from /opt/mikutter/core/plugin/gtk/delayer.rb:10:in `block in boot'
         from /opt/mikutter/core/plugin/gtk/mainloop.rb:10:in `main'
         from /opt/mikutter/core/plugin/gtk/mainloop.rb:10:in `mainloop'
         from /opt/mikutter/mikutter.rb:63:in `boot!'
         from /opt/mikutter/mikutter.rb:92:in `<main>'
/home/pocke/.gem/ruby/2.3.0/gems/yard-0.9.5/lib/yard/globals.rb:16:in `log': wrong number of arguments (given 2, expected 0) (ArgumentError)
        from /opt/mikutter/core/utils.rb:117:in `notice'
        from /opt/mikutter/mikutter.rb:80:in `error_handling!'
        from /opt/mikutter/mikutter.rb:103:in `rescue in <main>'
        from /opt/mikutter/mikutter.rb:84:in `<main>'

```

The stack trace has some debug code, so, line number has some offset.
The error is occurred at https://github.com/cosmo0920/mikutter_filter/blob/2569bca3f436bdc4a0e057884c17a813ca6d19c7/filter.rb#L55
## Cause

I think the cause is a change of Twitter API (or mikutter API).
## For example

The following tweet has entities, and url. However the tweet doesn't have expanded_url...

``` ruby
[118] pry(#<Plugin>)> m
=> #<Message: 781863182042222592 User(@103yen) RT @ume_retire: 明日10/1開催「立川防災航空祭」に立飛R-HMとR-53が展示されるとの報。一見面白みのない軽飛行機ですが、前者は「日本人では元陸軍エース・黒江保彦氏のみ操縦出来た仏人設計の珍機」、後者は「エンジンこそ英国製だが基本設計は戦前の…
 >
[119] pry(#<Plugin>)> m[:entities]
=> {:hashtags=>[],
 :urls=>[{:url=>"", :expanded_url=>nil, :indices=>[133, 133]}],
 :user_mentions=>[{:screen_name=>"ume_retire", :name=>"リタイ屋の梅", :id=>113338788, :id_str=>"113338788", :indices=>[3, 14]}],
 :symbols=>[]}
```
